### PR TITLE
Feat: add instant PDF rendering to Songbook Editor (YAML)

### DIFF
--- a/src/html/templates/songbook_edit/songbook_edit.html
+++ b/src/html/templates/songbook_edit/songbook_edit.html
@@ -117,6 +117,7 @@
                     <div class="action-buttons">
                         <button class="btn btn-primary" onclick="downloadYAML()">Pobierz plik .yaml</button>
                         <button class="btn btn-secondary" onclick="copyToClipboard()">Kopiuj do schowka</button>
+                        <button class="btn btn-primary" onclick="renderPDF()">Podgląd PDF</button>
                     </div>
                 </div>
             </div>

--- a/src/html/templates/songbook_edit/songbook_edit.js
+++ b/src/html/templates/songbook_edit/songbook_edit.js
@@ -611,6 +611,80 @@ function copyToClipboard() {
     alert('Skopiowano do schowka!');
 }
 
+async function renderPDF() {
+    const yaml = document.getElementById('yamlOutput').value;
+    if (!yaml) return;
+
+    // Get branch from URL or default to main
+    const urlParams = new URLSearchParams(window.location.search);
+    const branch = urlParams.get('branch') || 'main';
+
+    const payload = {
+        yaml_content: yaml,
+        branch: branch,
+        papersize: "a4"
+    };
+
+    try {
+        // Show loading notice
+        const btn = document.querySelector('button[onclick="renderPDF()"]');
+        const originalText = btn.textContent;
+        btn.textContent = "Generowanie...";
+        btn.disabled = true;
+        
+        const response = await fetch("https://songbook-pdf-render-177765940460.europe-west1.run.app/api/render/songbook_yaml", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify(payload)
+        });
+
+        if (!response.ok) {
+            alert("Błąd połączenia z serwerem PDF.");
+            btn.textContent = originalText;
+            btn.disabled = false;
+            return;
+        }
+
+        const data = await response.json();
+        const jobId = data.job_id;
+        
+        // Poll for completion
+        const pollInterval = setInterval(async () => {
+            try {
+                const statusRes = await fetch(`https://songbook-pdf-render-177765940460.europe-west1.run.app/api/jobs/${jobId}`);
+                if (statusRes.ok) {
+                    const statusData = await statusRes.json();
+                    if (statusData.status === "done") {
+                        clearInterval(pollInterval);
+                        btn.textContent = originalText;
+                        btn.disabled = false;
+                        window.open(`https://songbook-pdf-render-177765940460.europe-west1.run.app${statusData.url}`, "_blank");
+                    } else if (statusData.status === "error") {
+                        clearInterval(pollInterval);
+                        alert("Błąd generowania PDF. Sprawdź logi.");
+                        btn.textContent = originalText;
+                        btn.disabled = false;
+                        window.open(`https://songbook-pdf-render-177765940460.europe-west1.run.app${statusData.url}`, "_blank");
+                    }
+                }
+            } catch (e) {
+                console.error("Polling error", e);
+            }
+        }, 2000);
+
+    } catch (error) {
+        console.error("PDF render error", error);
+        alert("Błąd wysyłania do serwera PDF.");
+        const btn = document.querySelector('button[onclick="renderPDF()"]');
+        if (btn) {
+            btn.textContent = "Podgląd PDF";
+            btn.disabled = false;
+        }
+    }
+}
+
 // Auto-generate songbook ID from title
 let userEditedId = false; // Track if user manually edited the ID
 


### PR DESCRIPTION
## Summary
This adds the missing 'Podgląd PDF' button to the Songbook Editor (`songbook_edit.html`), which generates a full PDF of the songbook YAML. 

This was intended to be part of #311 but that PR was merged before these additional changes were pushed.

## Changes
- **`src/html/templates/songbook_edit/songbook_edit.html`**: Added 'Podgląd PDF' button
- **`src/html/templates/songbook_edit/songbook_edit.js`**: Added `renderPDF()` logic to POST the generated YAML to the Cloud Run backend and poll for completion.