### PR TITLE
feat: Single song editor improvements (PDF UI and backend fixes)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,9 @@
 .idea/
 .python_venv/
 .direnv/
+.venv/
 venv/
+test_venv/
 containers/backend/venv/
 build/
 npmtmp/

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -2,7 +2,9 @@
 .idea/
 .python_venv/
 .direnv/
+.venv/
 venv/
+test_venv/
 containers/backend/venv/
 build/
 npmtmp/

--- a/containers/backend/main.py
+++ b/containers/backend/main.py
@@ -135,7 +135,7 @@ def setup_work_dir(temp_dir: str) -> str:
         dst = os.path.join(work_dir, item)
         if os.path.exists(src):
             if os.path.isdir(src):
-                shutil.copytree(src, dst, dirs_exist_ok=True)
+                shutil.copytree(src, dst, dirs_exist_ok=True, symlinks=True, ignore_dangling_symlinks=True)
             else:
                 shutil.copy2(src, dst)
     return work_dir

--- a/editor/index.html
+++ b/editor/index.html
@@ -76,7 +76,7 @@
          await commit(e.target);
       } );
       songEditor.addEventListener("git:commitAndPublish", (e)=>commitAndPublish(e) );
-      songEditor.addEventListener("pdf:render", (e) => renderPdf(e.target));
+      songEditor.addEventListener("pdf:render", (e) => renderPdf(e.target, e.detail?.papersize || "a4"));
 
       const topNav = document.getElementById("topnav");
       for (const nav of [document.getElementById("topnav"), document.getElementById("bottomnav")]) {
@@ -232,52 +232,54 @@
       }
     }
 
-    async function renderPdf(songbook) {
+    async function renderPdf(songbook, papersize = "a4") {
       const {serialized, title} = songbook.SerializeWithChange();
       const {branch} = parseParams();
       
       const payload = {
         xml_content: serialized,
         format: "single",
-        papersize: "a4",
+        papersize: papersize,
         title: title || "Song",
         branch: branch || "main"
       };
 
+      const statusSpan = songbook.shadowRoot ? songbook.shadowRoot.getElementById("pdfRenderStatus") : null;
+
       renderPdfCloudRun(
         payload, 
         "/api/render/song_xml",
-        () => notice("Generowanie PDF... Proszę czekać (może potrwać do kilkunastu sekund)", songbook),
+        () => {
+            if (statusSpan) {
+                statusSpan.innerHTML = `<span style="color: #0056b3;">⏳ Generowanie PDF... (ok. 10-15s)</span>`;
+            } else {
+                notice("Generowanie PDF... Proszę czekać (może potrwać do kilkunastu sekund)", songbook);
+            }
+        },
         (url) => {
             const dateStr = new Date().toISOString().split('T')[0];
             const filename = encodeURIComponent(`${title || 'piosenka'}_${dateStr}.pdf`);
             const finalUrl = `${url}?filename=${filename}&disposition=inline`;
             
-            const noticeDiv = document.createElement("div");
-            noticeDiv.classList.add("notice");
-            noticeDiv.innerHTML = `
-              <div style="text-align: center;">
-                <p style="margin-bottom: 15px; color: #28a745; font-weight: bold; font-size: 1.1em;">PDF wygenerowany!</p>
-                <a href="${finalUrl}" target="_blank" style="
-                  display: inline-block;
-                  background: #28a745;
-                  color: white;
-                  padding: 12px 24px;
-                  text-decoration: none;
-                  border-radius: 6px;
-                  font-weight: bold;
-                  font-size: 1.1em;
-                  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-                  transition: background 0.2s;
-                ">Gotowe! Otwórz Podgląd PDF</a>
-                <div style="margin-top: 15px;">
-                  <a href="#" onclick="this.parentNode.parentNode.parentNode.remove(); return false;" style="color: #6c757d; font-size: 0.9em; text-decoration: underline;">Zamknij to okienko</a>
-                </div>
-              </div>
-            `;
-            document.body.appendChild(noticeDiv);
+            if (statusSpan) {
+                statusSpan.innerHTML = `<a href="${finalUrl}" target="_blank" style="color: #28a745; text-decoration: underline;">✅ Gotowe! Otwórz PDF</a>`;
+                setTimeout(() => { if (statusSpan.innerHTML.includes('Otwórz PDF')) statusSpan.innerHTML = ''; }, 60000);
+            } else {
+                const noticeDiv = document.createElement("div");
+                noticeDiv.classList.add("notice");
+                noticeDiv.innerHTML = `
+                  <div style="text-align: center;">
+                    <p style="margin-bottom: 15px; color: #28a745; font-weight: bold; font-size: 1.1em;">PDF wygenerowany!</p>
+                    <a href="${finalUrl}" target="_blank" style="display: inline-block; background: #28a745; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; font-weight: bold;">Otwórz Podgląd PDF</a>
+                    <div style="margin-top: 15px;"><a href="#" onclick="this.parentNode.parentNode.parentNode.remove(); return false;">Zamknij to okienko</a></div>
+                  </div>`;
+                document.body.appendChild(noticeDiv);
+            }
         },
         (err, errUrl) => {
+            if (statusSpan) {
+                statusSpan.innerHTML = `<span style="color: #dc3545;">❌ Błąd generowania PDF.</span>`;
+            }
             alert("Błąd generowania: " + err);
         }
       );

--- a/editor/songbook.js
+++ b/editor/songbook.js
@@ -32,6 +32,11 @@ export class SongEditor extends HTMLElement {
   <input type="button" id="openUrl" value="Importuj z sieci"/>  
   <button id="buttonSave">Eksportuj plik</button>
   <button id="buttonRenderPdf" type="button">Podgląd PDF</button>
+  <select id="pdfPapersize" style="margin-left: 5px;">
+    <option value="a4">A4</option>
+    <option value="a5">A5</option>
+  </select>
+  <span id="pdfRenderStatus" style="margin-left: 10px; font-weight: bold; font-size: 0.9em;"></span>
 </div>
 
 <div class="gitToolbar">
@@ -166,10 +171,12 @@ export class SongEditor extends HTMLElement {
     this.openUrl.addEventListener("click", () => this.OpenUrl());
     this.buttonSave.addEventListener("click", () => Save(this));
     this.buttonRenderPdf.addEventListener("click", () => {
+      const papersize = this.shadow.getElementById("pdfPapersize").value;
       const renderEvent = new CustomEvent("pdf:render", {
         bubbles: true,
         cancelable: true,
         composed: true,
+        detail: { papersize: papersize }
       });
       this.dispatchEvent(renderEvent);
     });

--- a/editor/songbook.js
+++ b/editor/songbook.js
@@ -212,6 +212,16 @@ export class SongEditor extends HTMLElement {
     }
 
     this.attributeChangedCallback("git");
+    
+    // Clear PDF "Gotowe" status if the user edits anything
+    const clearPdfStatus = () => {
+      const statusSpan = this.shadow.getElementById("pdfRenderStatus");
+      if (statusSpan && statusSpan.innerHTML.includes("Gotowe")) {
+        statusSpan.innerHTML = "";
+      }
+    };
+    this.shadow.addEventListener("input", clearPdfStatus);
+    this.shadow.addEventListener("change", clearPdfStatus);
   }
 
   mapAttribute(attr) {


### PR DESCRIPTION
This PR contains the recent fixes we discussed: 1. Adds A4/A5 PDF generation selector. 2. Integrates the 'PDF Wygenerowany' link cleanly inline instead of an ugly overlay popup. 3. Clears the PDF generation status when the song is edited to prevent clicking stale PDF links. 4. Fixes the backend 500 error caused by dangling symlinks breaking shutil.copytree. 5. Removes test_venv from gcloud build scope.